### PR TITLE
Drop dependency on deprecated `gulp-util`

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,9 +11,8 @@
  */
 
 var through2 						= require('through2'),
-	gutil							= require('gulp-util'),
+	PluginError						= require('plugin-error'),
 	SVGSpriter						= require('svg-sprite'),
-	PluginError						= gutil.PluginError,
 
 	PLUGIN_NAME						= 'gulp-svg-sprite';
 

--- a/package.json
+++ b/package.json
@@ -24,10 +24,9 @@
     "CHANGELOG.md"
   ],
   "dependencies": {
+    "plugin-error": "^0.1.2",
     "svg-sprite": "~1.3.7",
-    "through2": "^2.0.3",
-    "gulp-util": "^3.0.8",
-    "vinyl": "^2.0.2"
+    "through2": "^2.0.3"
   },
   "devDependencies": {
     "coveralls": "*",
@@ -40,11 +39,12 @@
     "istanbul": "*",
     "jshint": "^2.9.4",
     "mkdirp": "^0.5.1",
-    "pn": "^1.0.0",
     "mocha": "*",
     "mocha-lcov-reporter": "*",
+    "pn": "^1.0.0",
     "should": "~11.2.1",
-    "svg2png": "jkphl/svg2png"
+    "svg2png": "jkphl/svg2png",
+    "vinyl": "^2.1.0"
   },
   "keywords": [
     "gulpplugin",

--- a/test/svg_sprite_test.js
+++ b/test/svg_sprite_test.js
@@ -25,7 +25,7 @@ require('mocha');
 
 delete require.cache[require.resolve('../')];
 
-var gutil = require('gulp-util'),
+var Vinyl = require('vinyl'),
     gulpSvgSprite = require('../'),
     orthogonal = {
 //		log					: 'debug',
@@ -157,7 +157,7 @@ describe('gulp-svg-sprite', function () {
             });
 
             glob.glob.sync('weather*.svg', {cwd: cwd}).forEach(function (file) {
-                stream.write(new gutil.File({
+                stream.write(new Vinyl({
                     path: path.join(cwd, file),
                     cwd: cwd,
                     base: cwd,
@@ -218,7 +218,7 @@ describe('gulp-svg-sprite', function () {
             });
 
             glob.glob.sync('weather*.svg', {cwd: cwd}).forEach(function (file) {
-                stream.write(new gutil.File({
+                stream.write(new Vinyl({
                     path: path.join(cwd, file),
                     cwd: cwd,
                     base: cwd,


### PR DESCRIPTION
Closes jkphl/gulp-svg-sprite#74