### PR TITLE
use right year

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.4.0 Compatibility release (2019-03-17)
+## 1.4.0 Compatibility release (2018-03-17)
 * Compatible with [svg-sprite 1.4.0](https://github.com/jkphl/svg-sprite/tree/v1.4.0)
 * Updated dependencies
 * Drop dependency on deprecated `gulp-util` ([#74](https://github.com/jkphl/gulp-svg-sprite/issues/74), [#75](https://github.com/jkphl/gulp-svg-sprite/issues/75))


### PR DESCRIPTION
The changelog release-date was from the future (2019) but unless you´ve got a Tardis, Delorean or some other time machine we are still stuck in 2018 🙆 

Best Regards
Maxi :)